### PR TITLE
feat: Implement WalletTxns API (Phase 5.x - Issue #39)

### DIFF
--- a/accounting/wallettxns.go
+++ b/accounting/wallettxns.go
@@ -1,0 +1,196 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/muno/freee-api-go/internal/gen"
+)
+
+// ListWalletTxnsOptions contains optional parameters for listing wallet transactions.
+type ListWalletTxnsOptions struct {
+	// WalletableType filters by account type (口座区分)
+	// Values: "bank_account" (銀行口座), "credit_card" (クレジットカード), "wallet" (現金)
+	// Note: WalletableType and WalletableId must be specified together
+	WalletableType *string
+
+	// WalletableId filters by account ID (口座ID)
+	// Note: WalletableType and WalletableId must be specified together
+	WalletableId *int64
+
+	// StartDate filters by transaction date start (取引日：開始日 yyyy-mm-dd)
+	StartDate *string
+
+	// EndDate filters by transaction date end (取引日：終了日 yyyy-mm-dd)
+	EndDate *string
+
+	// EntrySide filters by income/expense type (入金／出金)
+	// Values: "income" (入金), "expense" (出金)
+	EntrySide *string
+
+	// Offset for pagination (デフォルト: 0)
+	Offset *int64
+
+	// Limit for pagination (デフォルト: 20, 最小: 1, 最大: 100)
+	Limit *int64
+}
+
+// ListWalletTxnsResult contains the result of listing wallet transactions.
+type ListWalletTxnsResult struct {
+	// WalletTxns is the list of wallet transactions
+	WalletTxns []gen.WalletTxn
+}
+
+// List retrieves a list of wallet transactions for the specified company.
+//
+// This method returns all wallet transactions matching the optional filter criteria.
+// Use ListWalletTxnsOptions to filter by account, dates, entry side, etc.
+//
+// Example:
+//
+//	opts := &accounting.ListWalletTxnsOptions{
+//	    WalletableType: stringPtr("bank_account"),
+//	    WalletableId:   int64Ptr(12345),
+//	    Limit:          int64Ptr(50),
+//	    Offset:         int64Ptr(0),
+//	}
+//	result, err := walletTxnService.List(ctx, companyID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, txn := range result.WalletTxns {
+//	    fmt.Printf("Txn ID: %d, Amount: %d, Description: %s\n", txn.Id, txn.Amount, txn.Description)
+//	}
+func (s *WalletTxnService) List(ctx context.Context, companyID int64, opts *ListWalletTxnsOptions) (*ListWalletTxnsResult, error) {
+	// Build parameters
+	params := &gen.GetWalletTxnsParams{
+		CompanyId: companyID,
+	}
+
+	if opts != nil {
+		params.WalletableId = opts.WalletableId
+		params.StartDate = opts.StartDate
+		params.EndDate = opts.EndDate
+		params.Offset = opts.Offset
+		params.Limit = opts.Limit
+
+		if opts.WalletableType != nil {
+			walletableType := gen.GetWalletTxnsParamsWalletableType(*opts.WalletableType)
+			params.WalletableType = &walletableType
+		}
+		if opts.EntrySide != nil {
+			entrySide := gen.GetWalletTxnsParamsEntrySide(*opts.EntrySide)
+			params.EntrySide = &entrySide
+		}
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetWalletTxnsWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list wallet transactions: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	// Return the result
+	return &ListWalletTxnsResult{
+		WalletTxns: resp.JSON200.WalletTxns,
+	}, nil
+}
+
+// Get retrieves a single wallet transaction by ID.
+//
+// Example:
+//
+//	txn, err := walletTxnService.Get(ctx, companyID, txnID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Wallet Transaction: %+v\n", txn)
+func (s *WalletTxnService) Get(ctx context.Context, companyID int64, txnID int64) (*gen.WalletTxnResponse, error) {
+	// Build parameters
+	params := &gen.GetWalletTxnParams{
+		CompanyId: companyID,
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetWalletTxnWithResponse(ctx, txnID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet transaction: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON200, nil
+}
+
+// Create creates a new wallet transaction.
+//
+// The params parameter should contain all required fields for creating a wallet transaction,
+// including company ID, walletable ID, walletable type, date, amount, entry side, etc.
+//
+// Example:
+//
+//	params := gen.WalletTxnParams{
+//	    CompanyId:      companyID,
+//	    WalletableId:   12345,
+//	    WalletableType: "bank_account",
+//	    Date:           "2024-01-15",
+//	    Amount:         10000,
+//	    EntrySide:      "income",
+//	    Description:    stringPtr("Payment received"),
+//	}
+//	txn, err := walletTxnService.Create(ctx, params)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Created wallet transaction ID: %d\n", txn.WalletTxn.Id)
+func (s *WalletTxnService) Create(ctx context.Context, params gen.WalletTxnParams) (*gen.WalletTxnResponse, error) {
+	// Call the generated client
+	resp, err := s.genClient.CreateWalletTxnWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wallet transaction: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON201, nil
+}
+
+// Delete deletes a wallet transaction by ID.
+//
+// Example:
+//
+//	err := walletTxnService.Delete(ctx, companyID, txnID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println("Wallet transaction deleted successfully")
+func (s *WalletTxnService) Delete(ctx context.Context, companyID int64, txnID int64) error {
+	// Build parameters
+	params := &gen.DestroyWalletTxnParams{
+		CompanyId: companyID,
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.DestroyWalletTxnWithResponse(ctx, txnID, params)
+	if err != nil {
+		return fmt.Errorf("failed to delete wallet transaction: %w", err)
+	}
+
+	// Check for error responses
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("failed to delete wallet transaction: %s", resp.Status())
+	}
+
+	return nil
+}

--- a/accounting/wallettxns_test.go
+++ b/accounting/wallettxns_test.go
@@ -1,0 +1,335 @@
+package accounting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/muno/freee-api-go/client"
+	"github.com/muno/freee-api-go/internal/gen"
+)
+
+func TestWalletTxnService_List(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		opts       *ListWalletTxnsOptions
+		mockStatus int
+		mockBody   string
+		wantErr    bool
+		wantCount  int
+	}{
+		{
+			name:       "successful list with no options",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"wallet_txns": [
+					{"id": 1, "company_id": 1, "amount": 10000, "date": "2024-01-15", "description": "Payment 1", "entry_side": "income"},
+					{"id": 2, "company_id": 1, "amount": 20000, "date": "2024-01-16", "description": "Payment 2", "entry_side": "expense"}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:      "successful list with options",
+			companyID: 1,
+			opts: &ListWalletTxnsOptions{
+				WalletableType: stringPtr("bank_account"),
+				WalletableId:   int64Ptr(12345),
+				EntrySide:      stringPtr("income"),
+				Limit:          int64Ptr(10),
+				Offset:         int64Ptr(0),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"wallet_txns": [
+					{"id": 3, "company_id": 1, "amount": 5000, "date": "2024-01-17", "description": "Income", "entry_side": "income"}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:       "empty result",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"wallet_txns": []
+			}`,
+			wantErr:   false,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/1/wallet_txns" {
+					t.Errorf("expected path /api/1/wallet_txns, got %s", r.URL.Path)
+				}
+
+				// Verify query parameters
+				query := r.URL.Query()
+				if query.Get("company_id") != "1" {
+					t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			walletTxnService := accountingClient.WalletTxns()
+			result, err := walletTxnService.List(context.Background(), tt.companyID, tt.opts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if result == nil {
+					t.Error("List() returned nil result")
+					return
+				}
+				if len(result.WalletTxns) != tt.wantCount {
+					t.Errorf("List() got %d wallet txns, want %d", len(result.WalletTxns), tt.wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestWalletTxnService_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		txnID      int64
+		mockStatus int
+		mockBody   string
+		wantErr    bool
+		wantTxnID  int64
+	}{
+		{
+			name:       "successful get",
+			companyID:  1,
+			txnID:      123,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"wallet_txn": {
+					"id": 123,
+					"company_id": 1,
+					"amount": 10000,
+					"date": "2024-01-15",
+					"description": "Payment",
+					"entry_side": "income",
+					"walletable_id": 12345,
+					"walletable_type": "bank_account"
+				}
+			}`,
+			wantErr:   false,
+			wantTxnID: 123,
+		},
+		{
+			name:       "successful get with different txn",
+			companyID:  1,
+			txnID:      456,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"wallet_txn": {
+					"id": 456,
+					"company_id": 1,
+					"amount": 20000,
+					"date": "2024-01-16",
+					"description": "Another payment",
+					"entry_side": "expense",
+					"walletable_id": 67890,
+					"walletable_type": "credit_card"
+				}
+			}`,
+			wantErr:   false,
+			wantTxnID: 456,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				expectedPath := "/api/1/wallet_txns/123"
+				if tt.txnID == 456 {
+					expectedPath = "/api/1/wallet_txns/456"
+				}
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			walletTxnService := accountingClient.WalletTxns()
+			txn, err := walletTxnService.Get(context.Background(), tt.companyID, tt.txnID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if txn == nil {
+					t.Error("Get() returned nil txn")
+					return
+				}
+				if txn.WalletTxn.Id != tt.wantTxnID {
+					t.Errorf("Get() got txn ID %d, want %d", txn.WalletTxn.Id, tt.wantTxnID)
+				}
+			}
+		})
+	}
+}
+
+func TestWalletTxnService_Create(t *testing.T) {
+	mockStatus := http.StatusCreated
+	mockBody := `{
+		"wallet_txn": {
+			"id": 999,
+			"company_id": 1,
+			"amount": 10000,
+			"date": "2024-01-15",
+			"description": "New transaction",
+			"entry_side": "income",
+			"walletable_id": 12345,
+			"walletable_type": "bank_account"
+		}
+	}`
+	wantTxnID := int64(999)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/1/wallet_txns" {
+			t.Errorf("expected path /api/1/wallet_txns, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	params := gen.WalletTxnParams{
+		CompanyId:      1,
+		WalletableId:   12345,
+		WalletableType: "bank_account",
+		Date:           "2024-01-15",
+		Amount:         10000,
+		EntrySide:      "income",
+	}
+
+	walletTxnService := accountingClient.WalletTxns()
+	txn, err := walletTxnService.Create(context.Background(), params)
+
+	if err != nil {
+		t.Errorf("Create() unexpected error = %v", err)
+		return
+	}
+
+	if txn == nil {
+		t.Error("Create() returned nil txn")
+		return
+	}
+	if txn.WalletTxn.Id != wantTxnID {
+		t.Errorf("Create() got txn ID %d, want %d", txn.WalletTxn.Id, wantTxnID)
+	}
+}
+
+func TestWalletTxnService_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		txnID      int64
+		mockStatus int
+		wantErr    bool
+	}{
+		{
+			name:       "successful delete",
+			companyID:  1,
+			txnID:      123,
+			mockStatus: http.StatusNoContent,
+			wantErr:    false,
+		},
+		{
+			name:       "delete with 200 OK",
+			companyID:  1,
+			txnID:      456,
+			mockStatus: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "delete not found",
+			companyID:  1,
+			txnID:      999,
+			mockStatus: http.StatusNotFound,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE request, got %s", r.Method)
+				}
+
+				w.WriteHeader(tt.mockStatus)
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			walletTxnService := accountingClient.WalletTxns()
+			err = walletTxnService.Delete(context.Background(), tt.companyID, tt.txnID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Issue #39 の実装: 口座明細（WalletTxns）APIのFacade実装

## 実装内容
- ✅ `accounting/wallettxns.go` 作成
- ✅ `WalletTxnService.List(ctx, opts)` 実装
- ✅ `WalletTxnService.Get(ctx, id)` 実装
- ✅ `WalletTxnService.Create(ctx, walletTxn)` 実装
- ✅ `WalletTxnService.Delete(ctx, id)` 実装
- ✅ エラーハンドリング実装
- ✅ ユニットテスト作成（4つのテストスイート）

## 変更内容
### 新規ファイル
- `accounting/wallettxns.go`: WalletTxnServiceの実装
  - List: 口座明細一覧の取得（フィルタリング対応）
  - Get: 個別口座明細の取得
  - Create: 口座明細の作成
  - Delete: 口座明細の削除
- `accounting/wallettxns_test.go`: 包括的なユニットテスト

### 主な機能
- 口座タイプ（銀行口座、クレジットカード、現金）によるフィルタリング
- 取引日による範囲検索
- 入金/出金での絞り込み
- ページネーション対応
- コンテキストの適切な処理
- 詳細なエラーハンドリング

## テスト結果
```
=== RUN   TestWalletTxnService_List
--- PASS: TestWalletTxnService_List (0.00s)
=== RUN   TestWalletTxnService_Get
--- PASS: TestWalletTxnService_Get (0.00s)
=== RUN   TestWalletTxnService_Create
--- PASS: TestWalletTxnService_Create (0.00s)
=== RUN   TestWalletTxnService_Delete
--- PASS: TestWalletTxnService_Delete (0.00s)
PASS
```

全てのテストが成功しています。

## 受け入れ基準の確認
- ✅ 全CRUD操作が実装されている
- ✅ コンテキストが適切に処理される
- ✅ エラーハンドリングが適切
- ✅ テストが全て成功する

## 参考実装
- `accounting/deals.go` - DealsServiceの実装パターンに従っています
- `accounting/services.go` - WalletTxnService構造体定義

## 関連Issue
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)