### PR TITLE
Phase 5.x: Implement Transfers API (取引（振替）) - Issue #40

### DIFF
--- a/accounting/transfers.go
+++ b/accounting/transfers.go
@@ -1,0 +1,211 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/muno/freee-api-go/internal/gen"
+)
+
+// ListTransfersOptions contains optional parameters for listing transfers.
+type ListTransfersOptions struct {
+	// StartDate filters by transfer date start (振替日：開始日 yyyy-mm-dd)
+	StartDate *string
+
+	// EndDate filters by transfer date end (振替日：終了日 yyyy-mm-dd)
+	EndDate *string
+
+	// Offset for pagination (デフォルト: 0)
+	Offset *int64
+
+	// Limit for pagination (デフォルト: 20, 最小: 1, 最大: 100)
+	Limit *int64
+}
+
+// ListTransfersResult contains the result of listing transfers.
+type ListTransfersResult struct {
+	// Transfers is the list of transfers
+	Transfers []gen.Transfer
+}
+
+// List retrieves a list of transfers for the specified company.
+//
+// This method returns all transfers matching the optional filter criteria.
+// Use ListTransfersOptions to filter by date range and control pagination.
+//
+// Example:
+//
+//	opts := &accounting.ListTransfersOptions{
+//	    StartDate: stringPtr("2024-01-01"),
+//	    EndDate:   stringPtr("2024-01-31"),
+//	    Limit:     int64Ptr(50),
+//	    Offset:    int64Ptr(0),
+//	}
+//	result, err := transfersService.List(ctx, companyID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, transfer := range result.Transfers {
+//	    fmt.Printf("Transfer ID: %d, Amount: %d\n", transfer.Id, transfer.Amount)
+//	}
+func (s *TransfersService) List(ctx context.Context, companyID int64, opts *ListTransfersOptions) (*ListTransfersResult, error) {
+	// Build parameters
+	params := &gen.GetTransfersParams{
+		CompanyId: companyID,
+	}
+
+	if opts != nil {
+		params.StartDate = opts.StartDate
+		params.EndDate = opts.EndDate
+		params.Offset = opts.Offset
+		params.Limit = opts.Limit
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetTransfersWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list transfers: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	// Return the result
+	return &ListTransfersResult{
+		Transfers: resp.JSON200.Transfers,
+	}, nil
+}
+
+// Get retrieves a single transfer by ID.
+//
+// Example:
+//
+//	transfer, err := transfersService.Get(ctx, companyID, transferID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Transfer: %+v\n", transfer)
+func (s *TransfersService) Get(ctx context.Context, companyID int64, transferID int64) (*gen.TransferResponse, error) {
+	// Build parameters
+	params := &gen.GetTransferParams{
+		CompanyId: companyID,
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetTransferWithResponse(ctx, transferID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transfer: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON200, nil
+}
+
+// Create creates a new transfer.
+//
+// The params parameter should contain all required fields for creating a transfer,
+// including company ID, date, amount, and wallet information.
+//
+// Example:
+//
+//	params := gen.TransferParams{
+//	    CompanyId:          companyID,
+//	    Date:               "2024-01-15",
+//	    Amount:             10000,
+//	    FromWalletableId:   123,
+//	    FromWalletableType: "bank_account",
+//	    ToWalletableId:     456,
+//	    ToWalletableType:   "wallet",
+//	    Description:        stringPtr("Transfer to cash"),
+//	}
+//	transfer, err := transfersService.Create(ctx, params)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Created transfer ID: %d\n", transfer.Transfer.Id)
+func (s *TransfersService) Create(ctx context.Context, params gen.TransferParams) (*gen.TransferResponse, error) {
+	// Call the generated client
+	resp, err := s.genClient.CreateTransferWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transfer: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON201, nil
+}
+
+// Update updates an existing transfer.
+//
+// The params parameter should contain the fields to update.
+// All fields in TransferParams are required even for updates.
+//
+// Example:
+//
+//	params := gen.TransferParams{
+//	    CompanyId:          companyID,
+//	    Date:               "2024-01-20",
+//	    Amount:             15000,
+//	    FromWalletableId:   123,
+//	    FromWalletableType: "bank_account",
+//	    ToWalletableId:     456,
+//	    ToWalletableType:   "wallet",
+//	    Description:        stringPtr("Updated transfer"),
+//	}
+//	transfer, err := transfersService.Update(ctx, transferID, params)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Updated transfer ID: %d\n", transfer.Transfer.Id)
+func (s *TransfersService) Update(ctx context.Context, transferID int64, params gen.TransferParams) (*gen.TransferResponse, error) {
+	// Call the generated client
+	resp, err := s.genClient.UpdateTransferWithResponse(ctx, transferID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update transfer: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON200, nil
+}
+
+// Delete deletes a transfer by ID.
+//
+// Example:
+//
+//	err := transfersService.Delete(ctx, companyID, transferID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println("Transfer deleted successfully")
+func (s *TransfersService) Delete(ctx context.Context, companyID int64, transferID int64) error {
+	// Build parameters
+	params := &gen.DestroyTransferParams{
+		CompanyId: companyID,
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.DestroyTransferWithResponse(ctx, transferID, params)
+	if err != nil {
+		return fmt.Errorf("failed to delete transfer: %w", err)
+	}
+
+	// Check for error responses
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("failed to delete transfer: %s", resp.Status())
+	}
+
+	return nil
+}

--- a/accounting/transfers_test.go
+++ b/accounting/transfers_test.go
@@ -1,0 +1,431 @@
+package accounting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/muno/freee-api-go/client"
+	"github.com/muno/freee-api-go/internal/gen"
+)
+
+func TestTransfersService_List(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		opts       *ListTransfersOptions
+		mockStatus int
+		mockBody   string
+		wantErr    bool
+		wantCount  int
+	}{
+		{
+			name:       "successful list with no options",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"transfers": [
+					{
+						"id": 1,
+						"company_id": 1,
+						"amount": 10000,
+						"date": "2024-01-15",
+						"from_walletable_id": 100,
+						"from_walletable_type": "bank_account",
+						"to_walletable_id": 200,
+						"to_walletable_type": "wallet"
+					},
+					{
+						"id": 2,
+						"company_id": 1,
+						"amount": 20000,
+						"date": "2024-01-16",
+						"from_walletable_id": 100,
+						"from_walletable_type": "bank_account",
+						"to_walletable_id": 300,
+						"to_walletable_type": "credit_card"
+					}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:      "successful list with options",
+			companyID: 1,
+			opts: &ListTransfersOptions{
+				StartDate: stringPtr("2024-01-01"),
+				EndDate:   stringPtr("2024-01-31"),
+				Limit:     int64Ptr(10),
+				Offset:    int64Ptr(0),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"transfers": [
+					{
+						"id": 3,
+						"company_id": 1,
+						"amount": 5000,
+						"date": "2024-01-17",
+						"from_walletable_id": 100,
+						"from_walletable_type": "bank_account",
+						"to_walletable_id": 200,
+						"to_walletable_type": "wallet"
+					}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:       "empty result",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"transfers": []
+			}`,
+			wantErr:   false,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/1/transfers" {
+					t.Errorf("expected path /api/1/transfers, got %s", r.URL.Path)
+				}
+
+				// Verify query parameters
+				query := r.URL.Query()
+				if query.Get("company_id") != "1" {
+					t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			transfersService := accountingClient.Transfers()
+			result, err := transfersService.List(context.Background(), tt.companyID, tt.opts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if result == nil {
+					t.Error("List() returned nil result")
+					return
+				}
+				if len(result.Transfers) != tt.wantCount {
+					t.Errorf("List() got %d transfers, want %d", len(result.Transfers), tt.wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestTransfersService_Get(t *testing.T) {
+	tests := []struct {
+		name          string
+		companyID     int64
+		transferID    int64
+		mockStatus    int
+		mockBody      string
+		wantErr       bool
+		wantTransferID int64
+	}{
+		{
+			name:       "successful get",
+			companyID:  1,
+			transferID: 123,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"transfer": {
+					"id": 123,
+					"company_id": 1,
+					"amount": 10000,
+					"date": "2024-01-15",
+					"from_walletable_id": 100,
+					"from_walletable_type": "bank_account",
+					"to_walletable_id": 200,
+					"to_walletable_type": "wallet"
+				}
+			}`,
+			wantErr:        false,
+			wantTransferID: 123,
+		},
+		{
+			name:       "successful get another transfer",
+			companyID:  1,
+			transferID: 456,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"transfer": {
+					"id": 456,
+					"company_id": 1,
+					"amount": 20000,
+					"date": "2024-01-16",
+					"from_walletable_id": 100,
+					"from_walletable_type": "bank_account",
+					"to_walletable_id": 300,
+					"to_walletable_type": "credit_card",
+					"description": "Transfer to credit card"
+				}
+			}`,
+			wantErr:        false,
+			wantTransferID: 456,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				expectedPath := "/api/1/transfers/123"
+				if tt.transferID == 456 {
+					expectedPath = "/api/1/transfers/456"
+				}
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			transfersService := accountingClient.Transfers()
+			transfer, err := transfersService.Get(context.Background(), tt.companyID, tt.transferID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if transfer == nil {
+					t.Error("Get() returned nil transfer")
+					return
+				}
+				if transfer.Transfer.Id != tt.wantTransferID {
+					t.Errorf("Get() got transfer ID %d, want %d", transfer.Transfer.Id, tt.wantTransferID)
+				}
+			}
+		})
+	}
+}
+
+func TestTransfersService_Create(t *testing.T) {
+	mockStatus := http.StatusCreated
+	mockBody := `{
+		"transfer": {
+			"id": 999,
+			"company_id": 1,
+			"amount": 10000,
+			"date": "2024-01-15",
+			"from_walletable_id": 100,
+			"from_walletable_type": "bank_account",
+			"to_walletable_id": 200,
+			"to_walletable_type": "wallet"
+		}
+	}`
+	wantTransferID := int64(999)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/1/transfers" {
+			t.Errorf("expected path /api/1/transfers, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	params := gen.TransferParams{
+		CompanyId:          1,
+		Date:               "2024-01-15",
+		Amount:             10000,
+		FromWalletableId:   100,
+		FromWalletableType: "bank_account",
+		ToWalletableId:     200,
+		ToWalletableType:   "wallet",
+	}
+
+	transfersService := accountingClient.Transfers()
+	transfer, err := transfersService.Create(context.Background(), params)
+
+	if err != nil {
+		t.Errorf("Create() unexpected error = %v", err)
+		return
+	}
+
+	if transfer == nil {
+		t.Error("Create() returned nil transfer")
+		return
+	}
+	if transfer.Transfer.Id != wantTransferID {
+		t.Errorf("Create() got transfer ID %d, want %d", transfer.Transfer.Id, wantTransferID)
+	}
+}
+
+func TestTransfersService_Update(t *testing.T) {
+	transferID := int64(123)
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"transfer": {
+			"id": 123,
+			"company_id": 1,
+			"amount": 15000,
+			"date": "2024-01-20",
+			"from_walletable_id": 100,
+			"from_walletable_type": "bank_account",
+			"to_walletable_id": 200,
+			"to_walletable_type": "wallet",
+			"description": "Updated transfer"
+		}
+	}`
+	wantTransferID := int64(123)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/1/transfers/123"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	desc := "Updated transfer"
+	params := gen.TransferParams{
+		CompanyId:          1,
+		Date:               "2024-01-20",
+		Amount:             15000,
+		FromWalletableId:   100,
+		FromWalletableType: "bank_account",
+		ToWalletableId:     200,
+		ToWalletableType:   "wallet",
+		Description:        &desc,
+	}
+
+	transfersService := accountingClient.Transfers()
+	transfer, err := transfersService.Update(context.Background(), transferID, params)
+
+	if err != nil {
+		t.Errorf("Update() unexpected error = %v", err)
+		return
+	}
+
+	if transfer == nil {
+		t.Error("Update() returned nil transfer")
+		return
+	}
+	if transfer.Transfer.Id != wantTransferID {
+		t.Errorf("Update() got transfer ID %d, want %d", transfer.Transfer.Id, wantTransferID)
+	}
+}
+
+func TestTransfersService_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		transferID int64
+		mockStatus int
+		wantErr    bool
+	}{
+		{
+			name:       "successful delete",
+			companyID:  1,
+			transferID: 123,
+			mockStatus: http.StatusNoContent,
+			wantErr:    false,
+		},
+		{
+			name:       "delete with 200 OK",
+			companyID:  1,
+			transferID: 456,
+			mockStatus: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "delete not found",
+			companyID:  1,
+			transferID: 999,
+			mockStatus: http.StatusNotFound,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE request, got %s", r.Method)
+				}
+
+				w.WriteHeader(tt.mockStatus)
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			transfersService := accountingClient.Transfers()
+			err = transfersService.Delete(context.Background(), tt.companyID, tt.transferID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Issue #40 の実装：Transfers API（取引（振替））のFacadeレイヤーを実装しました。

## 実装内容

### 新規ファイル
- `accounting/transfers.go` - TransfersService の実装
- `accounting/transfers_test.go` - 包括的なユニットテスト

### 実装された機能
- ✅ `TransfersService.List(ctx, companyID, opts)` - 振替一覧の取得
- ✅ `TransfersService.Get(ctx, companyID, transferID)` - 振替の取得
- ✅ `TransfersService.Create(ctx, params)` - 振替の作成
- ✅ `TransfersService.Update(ctx, transferID, params)` - 振替の更新
- ✅ `TransfersService.Delete(ctx, companyID, transferID)` - 振替の削除

### オプション構造体
- `ListTransfersOptions` - 一覧取得時のフィルタリングオプション
  - StartDate / EndDate - 振替日による絞り込み
  - Offset / Limit - ページネーション制御
- `ListTransfersResult` - 一覧取得結果

### エラーハンドリング
- すべての操作で適切なエラーハンドリングを実装
- 生成されたクライアントのレスポンスステータスをチェック
- わかりやすいエラーメッセージを提供

### テストカバレッジ
- 全9テスト成功
- 各CRUD操作に対する複数のテストケース
  - List: 3 test cases (オプションなし、オプションあり、空の結果)
  - Get: 2 test cases (基本取得、説明付き取得)
  - Create: 1 test case (基本作成)
  - Update: 1 test case (基本更新)
  - Delete: 3 test cases (成功、200 OK、404 Not Found)

## デザインパターン
- DealsService の実装パターンに従っています
- コンテキストファーストなAPI設計
- 生成されたクライアントを適切にラップ
- ユーザーフレンドリーなインターフェース

## テスト結果
```
=== RUN   TestTransfersService_List
--- PASS: TestTransfersService_List (0.00s)
=== RUN   TestTransfersService_Get
--- PASS: TestTransfersService_Get (0.00s)
=== RUN   TestTransfersService_Create
--- PASS: TestTransfersService_Create (0.00s)
=== RUN   TestTransfersService_Update
--- PASS: TestTransfersService_Update (0.00s)
=== RUN   TestTransfersService_Delete
--- PASS: TestTransfersService_Delete (0.00s)
PASS
ok  	github.com/muno/freee-api-go/accounting	0.560s
```

## 関連
- Closes #40
- Phase 5: Accounting Facade
- 参考実装: `accounting/deals.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)