### PR TITLE
feat: Implement Journals API facade (Phase 5.4)

### DIFF
--- a/accounting/journals.go
+++ b/accounting/journals.go
@@ -1,0 +1,253 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/muno/freee-api-go/internal/gen"
+)
+
+// Note: JournalsService type is declared in services.go
+
+// DownloadJournalsOptions contains optional parameters for downloading journals.
+type DownloadJournalsOptions struct {
+	// Encoding specifies the character encoding (文字コード)
+	// Values: "sjis" (Shift-JIS), "utf-8" (UTF-8)
+	Encoding *string
+
+	// VisibleTags specifies items to output as auxiliary subjects or comments
+	// (補助科目やコメントとして出力する項目)
+	// Values: "partner", "item", "tag", "section", "description",
+	//         "wallet_txn_description", "segment_1_tag", "segment_2_tag",
+	//         "segment_3_tag", "all"
+	VisibleTags *[]string
+
+	// VisibleIds specifies additional ID items to output (追加出力するID項目)
+	// Values: "deal_id", "transfer_id", "manual_journal_id"
+	VisibleIds *[]string
+
+	// StartDate filters by start date (取得開始日 yyyy-mm-dd)
+	StartDate *string
+
+	// EndDate filters by end date (取得終了日 yyyy-mm-dd)
+	EndDate *string
+}
+
+// DownloadJournalsResult contains the result of downloading journals.
+type DownloadJournalsResult struct {
+	// Journals contains the journal download information
+	Journals gen.JournalsResponse
+}
+
+// ListManualJournalsOptions contains optional parameters for listing manual journals.
+type ListManualJournalsOptions struct {
+	// StartIssueDate filters by issue date start (発生日で絞込：開始日 yyyy-mm-dd)
+	StartIssueDate *string
+
+	// EndIssueDate filters by issue date end (発生日で絞込：終了日 yyyy-mm-dd)
+	EndIssueDate *string
+
+	// EntrySide filters by debit/credit side (貸借で絞込)
+	// Values: "credit" (貸方), "debit" (借方)
+	EntrySide *string
+
+	// AccountItemId filters by account item ID (勘定科目IDで絞込)
+	AccountItemId *int64
+
+	// MinAmount filters by minimum amount (金額で絞込：下限)
+	MinAmount *int64
+
+	// MaxAmount filters by maximum amount (金額で絞込：上限)
+	MaxAmount *int64
+
+	// PartnerId filters by partner ID (取引先IDで絞込)
+	PartnerId *int64
+
+	// PartnerCode filters by partner code (取引先コードで絞込)
+	PartnerCode *string
+
+	// ItemId filters by item ID (品目IDで絞込)
+	ItemId *int64
+
+	// SectionId filters by section ID (部門IDで絞込)
+	SectionId *int64
+
+	// Segment1TagId filters by segment 1 tag ID (セグメント1IDで絞込)
+	Segment1TagId *int64
+
+	// Segment2TagId filters by segment 2 tag ID (セグメント2IDで絞込)
+	Segment2TagId *int64
+
+	// Segment3TagId filters by segment 3 tag ID (セグメント3IDで絞込)
+	Segment3TagId *int64
+
+	// CommentStatus filters by comment status (コメント状態で絞込)
+	// Values: "posted" (コメントあり), "raised" (未解決), "resolved" (解決済み)
+	CommentStatus *string
+
+	// CommentImportant filters by important comment flag (重要コメントで絞込)
+	CommentImportant *bool
+
+	// Adjustment filters by adjustment transaction (決算整理仕訳で絞込)
+	// Values: "only" (決算整理仕訳のみ), "without" (決算整理仕訳以外)
+	Adjustment *string
+
+	// TxnNumber filters by transaction number (仕訳番号で絞込)
+	TxnNumber *string
+
+	// Offset for pagination (デフォルト: 0)
+	Offset *int64
+
+	// Limit for pagination (デフォルト: 20, 最大: 500)
+	Limit *int64
+}
+
+// ListManualJournalsResult contains the result of listing manual journals.
+type ListManualJournalsResult struct {
+	// ManualJournals is the list of manual journals
+	ManualJournals []gen.ManualJournal
+}
+
+// Download initiates a journal download request.
+//
+// This method requests the freee API to generate journal data in the specified format.
+// The actual download must be handled separately using the returned download URL.
+//
+// Example:
+//
+//	opts := &accounting.DownloadJournalsOptions{
+//	    StartDate: stringPtr("2024-01-01"),
+//	    EndDate:   stringPtr("2024-01-31"),
+//	    Encoding:  stringPtr("utf-8"),
+//	}
+//	result, err := journalsService.Download(ctx, companyID, "csv", opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Download ID: %d, Status: %s\n", result.Journals.Id, result.Journals.Status)
+func (s *JournalsService) Download(ctx context.Context, companyID int64, downloadType string, opts *DownloadJournalsOptions) (*DownloadJournalsResult, error) {
+	// Build parameters
+	params := &gen.GetJournalsParams{
+		CompanyId:    companyID,
+		DownloadType: gen.GetJournalsParamsDownloadType(downloadType),
+	}
+
+	if opts != nil {
+		if opts.Encoding != nil {
+			encoding := gen.GetJournalsParamsEncoding(*opts.Encoding)
+			params.Encoding = &encoding
+		}
+
+		if opts.VisibleTags != nil {
+			visibleTags := make([]gen.GetJournalsParamsVisibleTags, len(*opts.VisibleTags))
+			for i, tag := range *opts.VisibleTags {
+				visibleTags[i] = gen.GetJournalsParamsVisibleTags(tag)
+			}
+			params.VisibleTags = &visibleTags
+		}
+
+		if opts.VisibleIds != nil {
+			visibleIds := make([]gen.GetJournalsParamsVisibleIds, len(*opts.VisibleIds))
+			for i, id := range *opts.VisibleIds {
+				visibleIds[i] = gen.GetJournalsParamsVisibleIds(id)
+			}
+			params.VisibleIds = &visibleIds
+		}
+
+		params.StartDate = opts.StartDate
+		params.EndDate = opts.EndDate
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetJournalsWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download journals: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON202 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	// Return the result
+	return &DownloadJournalsResult{
+		Journals: *resp.JSON202,
+	}, nil
+}
+
+// List retrieves a list of manual journals for the specified company.
+//
+// This method returns all manual journals matching the optional filter criteria.
+// Use ListManualJournalsOptions to filter by date, amount, account items, etc.
+//
+// Example:
+//
+//	opts := &accounting.ListManualJournalsOptions{
+//	    StartIssueDate: stringPtr("2024-01-01"),
+//	    EndIssueDate:   stringPtr("2024-01-31"),
+//	    Limit:          int64Ptr(100),
+//	    Offset:         int64Ptr(0),
+//	}
+//	result, err := journalsService.List(ctx, companyID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, journal := range result.ManualJournals {
+//	    fmt.Printf("Journal ID: %d, Issue Date: %s\n", journal.Id, journal.IssueDate)
+//	}
+func (s *JournalsService) List(ctx context.Context, companyID int64, opts *ListManualJournalsOptions) (*ListManualJournalsResult, error) {
+	// Build parameters
+	params := &gen.GetManualJournalsParams{
+		CompanyId: companyID,
+	}
+
+	if opts != nil {
+		params.StartIssueDate = opts.StartIssueDate
+		params.EndIssueDate = opts.EndIssueDate
+		params.AccountItemId = opts.AccountItemId
+		params.MinAmount = opts.MinAmount
+		params.MaxAmount = opts.MaxAmount
+		params.PartnerId = opts.PartnerId
+		params.PartnerCode = opts.PartnerCode
+		params.ItemId = opts.ItemId
+		params.SectionId = opts.SectionId
+		params.Segment1TagId = opts.Segment1TagId
+		params.Segment2TagId = opts.Segment2TagId
+		params.Segment3TagId = opts.Segment3TagId
+		params.CommentImportant = opts.CommentImportant
+		params.TxnNumber = opts.TxnNumber
+		params.Offset = opts.Offset
+		params.Limit = opts.Limit
+
+		if opts.EntrySide != nil {
+			entrySide := gen.GetManualJournalsParamsEntrySide(*opts.EntrySide)
+			params.EntrySide = &entrySide
+		}
+
+		if opts.CommentStatus != nil {
+			commentStatus := gen.GetManualJournalsParamsCommentStatus(*opts.CommentStatus)
+			params.CommentStatus = &commentStatus
+		}
+
+		if opts.Adjustment != nil {
+			adjustment := gen.GetManualJournalsParamsAdjustment(*opts.Adjustment)
+			params.Adjustment = &adjustment
+		}
+	}
+
+	// Call the generated client
+	resp, err := s.genClient.GetManualJournalsWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list manual journals: %w", err)
+	}
+
+	// Handle error responses
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	// Return the result
+	return &ListManualJournalsResult{
+		ManualJournals: resp.JSON200.ManualJournals,
+	}, nil
+}

--- a/accounting/journals_test.go
+++ b/accounting/journals_test.go
@@ -1,0 +1,355 @@
+package accounting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/muno/freee-api-go/client"
+)
+
+func TestJournalsService_Download(t *testing.T) {
+	tests := []struct {
+		name         string
+		companyID    int64
+		downloadType string
+		opts         *DownloadJournalsOptions
+		mockStatus   int
+		mockBody     string
+		wantErr      bool
+		wantID       int64
+	}{
+		{
+			name:         "successful download with no options",
+			companyID:    1,
+			downloadType: "csv",
+			opts:         nil,
+			mockStatus:   http.StatusAccepted,
+			mockBody: `{
+				"journals": {
+					"id": 123,
+					"company_id": 1,
+					"download_type": "csv",
+					"start_date": "2024-01-01",
+					"end_date": "2024-01-31"
+				}
+			}`,
+			wantErr: false,
+			wantID:  123,
+		},
+		{
+			name:         "successful download with options",
+			companyID:    1,
+			downloadType: "csv",
+			opts: &DownloadJournalsOptions{
+				StartDate: stringPtr("2024-01-01"),
+				EndDate:   stringPtr("2024-01-31"),
+				Encoding:  stringPtr("utf-8"),
+			},
+			mockStatus: http.StatusAccepted,
+			mockBody: `{
+				"journals": {
+					"id": 456,
+					"company_id": 1,
+					"download_type": "csv",
+					"start_date": "2024-01-01",
+					"end_date": "2024-01-31",
+					"encoding": "utf-8"
+				}
+			}`,
+			wantErr: false,
+			wantID:  456,
+		},
+		{
+			name:         "download with visible tags and IDs",
+			companyID:    1,
+			downloadType: "generic",
+			opts: &DownloadJournalsOptions{
+				StartDate:   stringPtr("2024-01-01"),
+				EndDate:     stringPtr("2024-01-31"),
+				VisibleTags: &[]string{"partner", "item", "tag"},
+				VisibleIds:  &[]string{"deal_id", "manual_journal_id"},
+			},
+			mockStatus: http.StatusAccepted,
+			mockBody: `{
+				"journals": {
+					"id": 789,
+					"company_id": 1,
+					"download_type": "generic",
+					"start_date": "2024-01-01",
+					"end_date": "2024-01-31",
+					"visible_tags": ["partner", "item", "tag"],
+					"visible_ids": ["deal_id", "manual_journal_id"]
+				}
+			}`,
+			wantErr: false,
+			wantID:  789,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/1/journals" {
+					t.Errorf("expected path /api/1/journals, got %s", r.URL.Path)
+				}
+
+				// Verify query parameters
+				query := r.URL.Query()
+				if query.Get("company_id") != "1" {
+					t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+				}
+				if query.Get("download_type") != tt.downloadType {
+					t.Errorf("expected download_type=%s, got %s", tt.downloadType, query.Get("download_type"))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			journalsService := accountingClient.Journals()
+			result, err := journalsService.Download(context.Background(), tt.companyID, tt.downloadType, tt.opts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Download() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if result == nil {
+					t.Error("Download() returned nil result")
+					return
+				}
+				if result.Journals.Journals.Id != tt.wantID {
+					t.Errorf("Download() got ID %d, want %d", result.Journals.Journals.Id, tt.wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestJournalsService_List(t *testing.T) {
+	tests := []struct {
+		name       string
+		companyID  int64
+		opts       *ListManualJournalsOptions
+		mockStatus int
+		mockBody   string
+		wantErr    bool
+		wantCount  int
+	}{
+		{
+			name:       "successful list with no options",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 1,
+						"company_id": 1,
+						"issue_date": "2024-01-15",
+						"txn_number": "001"
+					},
+					{
+						"id": 2,
+						"company_id": 1,
+						"issue_date": "2024-01-16",
+						"txn_number": "002"
+					}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:      "successful list with date filter",
+			companyID: 1,
+			opts: &ListManualJournalsOptions{
+				StartIssueDate: stringPtr("2024-01-01"),
+				EndIssueDate:   stringPtr("2024-01-31"),
+				Limit:          int64Ptr(50),
+				Offset:         int64Ptr(0),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 3,
+						"company_id": 1,
+						"issue_date": "2024-01-20",
+						"txn_number": "003"
+					}
+				]
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:      "successful list with amount filter",
+			companyID: 1,
+			opts: &ListManualJournalsOptions{
+				MinAmount: int64Ptr(1000),
+				MaxAmount: int64Ptr(10000),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 4,
+						"company_id": 1,
+						"issue_date": "2024-01-25",
+						"txn_number": "004"
+					}
+				]
+				
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+			
+		},
+		{
+			name:      "successful list with account and partner filters",
+			companyID: 1,
+			opts: &ListManualJournalsOptions{
+				AccountItemId: int64Ptr(12345),
+				PartnerId:     int64Ptr(67890),
+				PartnerCode:   stringPtr("PARTNER001"),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 5,
+						"company_id": 1,
+						"issue_date": "2024-01-28",
+						"txn_number": "005"
+					}
+				]
+				
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+			
+		},
+		{
+			name:      "successful list with entry side filter",
+			companyID: 1,
+			opts: &ListManualJournalsOptions{
+				EntrySide: stringPtr("debit"),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 6,
+						"company_id": 1,
+						"issue_date": "2024-01-30",
+						"txn_number": "006"
+					}
+				]
+				
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+			
+		},
+		{
+			name:      "successful list with segment filters",
+			companyID: 1,
+			opts: &ListManualJournalsOptions{
+				Segment1TagId: int64Ptr(111),
+				Segment2TagId: int64Ptr(222),
+				Segment3TagId: int64Ptr(333),
+			},
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": [
+					{
+						"id": 7,
+						"company_id": 1,
+						"issue_date": "2024-01-31",
+						"txn_number": "007"
+					}
+				]
+				
+			}`,
+			wantErr:   false,
+			wantCount: 1,
+			
+		},
+		{
+			name:       "empty result",
+			companyID:  1,
+			opts:       nil,
+			mockStatus: http.StatusOK,
+			mockBody: `{
+				"manual_journals": []
+				
+			}`,
+			wantErr:   false,
+			wantCount: 0,
+			
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/1/manual_journals" {
+					t.Errorf("expected path /api/1/manual_journals, got %s", r.URL.Path)
+				}
+
+				// Verify query parameters
+				query := r.URL.Query()
+				if query.Get("company_id") != "1" {
+					t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			journalsService := accountingClient.Journals()
+			result, err := journalsService.List(context.Background(), tt.companyID, tt.opts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if result == nil {
+					t.Error("List() returned nil result")
+					return
+				}
+				if len(result.ManualJournals) != tt.wantCount {
+					t.Errorf("List() got %d manual journals, want %d", len(result.ManualJournals), tt.wantCount)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Implements the Journals API facade for freee accounting operations, completing Phase 5.4 of the project roadmap.

## Changes
- **accounting/journals.go**: 
  - `JournalsService.Download()`: Initiates journal download (仕訳帳ダウンロード) with support for various formats (CSV, PDF, Generic)
  - `JournalsService.List()`: Lists manual journals (振替伝票一覧取得) with comprehensive filtering options
  - Support for filtering by dates, amounts, account items, partners, segments, and more
- **accounting/journals_test.go**: 
  - Comprehensive unit tests (10 test cases)
  - Tests for Download() with various options (encoding, visible tags/IDs)
  - Tests for List() with multiple filter combinations

## Implementation Details
- Follows existing patterns from DealsService implementation
- Properly handles generated client response types (JSON202 for journals, JSON200 for manual journals)
- Implements all filter options from the freee API specification
- Full error handling and response validation
- All tests passing

## Testing
```bash
go test -v ./accounting/... -run TestJournalsService
```
All 10 test cases pass successfully.

## Related
- Closes #16 (Phase 5.4: Implement Journals API)
- Part of Phase 5: Accounting Facade implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)