### PR TITLE
chore: Update Go version requirement from 1.21 to 1.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Run tests
         run: go test -v ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ freee-api-go への貢献に興味をお持ちいただきありがとうござ�
 
 ### 前提条件
 
-- Go 1.21 以降
+- Go 1.24 以降
 - Git
 - golangci-lint（リンター用）
 - Make（オプション、Makefileコマンド使用時）

--- a/PLAN.md
+++ b/PLAN.md
@@ -156,7 +156,7 @@ freee APIのOpenAPI仕様は以下から取得:
 
 ### 7.1 コード品質
 
-- Go Modules対応（go 1.21+）
+- Go Modules対応（go 1.24+）
 - GoDocによるAPIドキュメント生成
 - golangci-lint による静的解析
 - コードカバレッジ 80%以上を目標

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/u-masato/freee-api-go.svg)](https://pkg.go.dev/github.com/u-masato/freee-api-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/u-masato/freee-api-go)](https://goreportcard.com/report/github.com/u-masato/freee-api-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://golang.org/)
 
 freee（フリー株式会社）が提供する会計API用のGo言語クライアントライブラリ（SDK）です。
 
@@ -43,7 +43,7 @@ freee（フリー株式会社）が提供する会計API用のGo言語クライ�
 
 ### 必要要件
 
-- **Go 1.21以上**
+- **Go 1.24以上**
 - **freee開発者アカウント**（[freee開発者ポータル](https://developer.freee.co.jp/)で作成）
 
 ### インストール方法

--- a/TODO.md
+++ b/TODO.md
@@ -263,7 +263,7 @@ mkdir -p {client,auth,accounting,transport,internal/{gen,testutil},examples/{oau
 - [x] `LoggingRoundTripper` 実装
   - リクエスト/レスポンスログ
   - シークレットマスキング（Authorization, Cookie, API-Key）
-  - slog（Go 1.21+）利用
+  - slog（Go 1.24+）利用
   - 構造化ログ出力
 - [x] ロギングテスト作成（7テスト成功）
 


### PR DESCRIPTION
## Summary

- Update Go version requirement from 1.21 to 1.24 across all documentation and CI configuration

## Changes

- `README.md`: Update Go version badge and requirements section
- `CONTRIBUTING.md`: Update prerequisites
- `TODO.md`: Update slog reference
- `PLAN.md`: Update Go Modules reference
- `.github/workflows/release.yml`: Update go-version for release workflow

## Test plan

- [ ] CI passes with Go 1.24
- [ ] Documentation is consistent across all files