### PR TITLE
chore: Migrate golangci-lint to v2 and apply formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,29 @@
+version: "2"
+
 run:
   timeout: 5m
   tests: true
   modules-download-mode: readonly
 
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-    - gofmt
-    - goimports
     - misspell
     - revive
-    - stylecheck
     - unconvert
     - unparam
     - gosec
     - bodyclose
     - noctx
-    - exportloopref
     - gocritic
     - godot
     - gocyclo
@@ -89,10 +91,7 @@ linters-settings:
 
   gosec:
     excludes:
-      - G104 # Audit errors not checked
-    config:
-      G111: # Detect potential directory traversal
-        enabled: true
+      - G104
 
 issues:
   exclude-rules:
@@ -118,7 +117,6 @@ issues:
   max-same-issues: 0
 
 output:
-  format: colored-line-number
   print-issued-lines: true
   print-linter-name: true
   sort-results: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test lint generate update-openapi clean coverage
+.PHONY: help build test lint fmt generate update-openapi clean coverage
 
 # Default target
 help:
@@ -6,6 +6,7 @@ help:
 	@echo "  make build           - Build all packages"
 	@echo "  make test            - Run all tests"
 	@echo "  make lint            - Run golangci-lint"
+	@echo "  make fmt             - Format code with go fmt"
 	@echo "  make generate        - Generate code from OpenAPI spec"
 	@echo "  make update-openapi  - Download latest OpenAPI specification"
 	@echo "  make clean           - Clean build artifacts"
@@ -25,6 +26,11 @@ test:
 lint:
 	@echo "Running linter..."
 	@golangci-lint run --timeout=5m
+
+# Format code
+fmt:
+	@echo "Formatting code..."
+	@go fmt ./...
 
 # Generate code from OpenAPI spec
 generate:

--- a/accounting/deals_test.go
+++ b/accounting/deals_test.go
@@ -395,7 +395,7 @@ func TestDealsService_Delete(t *testing.T) {
 	}
 }
 
-// Helper functions
+// Helper functions.
 func stringPtr(s string) *string {
 	return &s
 }

--- a/accounting/journals_test.go
+++ b/accounting/journals_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/u-masato/freee-api-go/internal/gen"
 )
 
-// Helper functions for journals tests
+// Helper functions for journals tests.
 func stringPtrJ(s string) *string {
 	return &s
 }
@@ -232,7 +232,6 @@ func TestJournalsService_List(t *testing.T) {
 			}`,
 			wantErr:   false,
 			wantCount: 1,
-			
 		},
 		{
 			name:      "successful list with account and partner filters",
@@ -256,7 +255,6 @@ func TestJournalsService_List(t *testing.T) {
 			}`,
 			wantErr:   false,
 			wantCount: 1,
-			
 		},
 		{
 			name:      "successful list with entry side filter",
@@ -278,7 +276,6 @@ func TestJournalsService_List(t *testing.T) {
 			}`,
 			wantErr:   false,
 			wantCount: 1,
-			
 		},
 		{
 			name:      "successful list with segment filters",
@@ -302,7 +299,6 @@ func TestJournalsService_List(t *testing.T) {
 			}`,
 			wantErr:   false,
 			wantCount: 1,
-			
 		},
 		{
 			name:       "empty result",
@@ -315,7 +311,6 @@ func TestJournalsService_List(t *testing.T) {
 			}`,
 			wantErr:   false,
 			wantCount: 0,
-			
 		},
 	}
 

--- a/accounting/partners.go
+++ b/accounting/partners.go
@@ -228,6 +228,7 @@ func (s *PartnersService) Delete(ctx context.Context, companyID int64, partnerID
 //	if err := iter.Err(); err != nil {
 //	    log.Fatal(err)
 //	}
+//
 // PartnerListItem is the type for individual partner items in list responses.
 // This is a type alias for the inline struct used in PartnersResponse.
 type PartnerListItem = struct {
@@ -251,27 +252,27 @@ type PartnerListItem = struct {
 	NameKana                     *string `json:"name_kana"`
 	OrgCode                      *int64  `json:"org_code"`
 	PartnerBankAccountAttributes *struct {
-		AccountName     *string                                                           `json:"account_name"`
-		AccountNumber   *string                                                           `json:"account_number"`
+		AccountName     *string                                                              `json:"account_name"`
+		AccountNumber   *string                                                              `json:"account_number"`
 		AccountType     *gen.PartnersResponsePartnersPartnerBankAccountAttributesAccountType `json:"account_type"`
-		BankCode        *string                                                           `json:"bank_code"`
-		BankName        *string                                                           `json:"bank_name"`
-		BankNameKana    *string                                                           `json:"bank_name_kana"`
-		BranchCode      *string                                                           `json:"branch_code"`
-		BranchKana      *string                                                           `json:"branch_kana"`
-		BranchName      *string                                                           `json:"branch_name"`
-		LongAccountName *string                                                           `json:"long_account_name"`
+		BankCode        *string                                                              `json:"bank_code"`
+		BankName        *string                                                              `json:"bank_name"`
+		BankNameKana    *string                                                              `json:"bank_name_kana"`
+		BranchCode      *string                                                              `json:"branch_code"`
+		BranchKana      *string                                                              `json:"branch_kana"`
+		BranchName      *string                                                              `json:"branch_name"`
+		LongAccountName *string                                                              `json:"long_account_name"`
 	} `json:"partner_bank_account_attributes,omitempty"`
 	PartnerDocSettingAttributes *struct {
 		SendingMethod *gen.PartnersResponsePartnersPartnerDocSettingAttributesSendingMethod `json:"sending_method"`
 	} `json:"partner_doc_setting_attributes,omitempty"`
-	PayerWalletableId       *int64                                           `json:"payer_walletable_id"`
-	Phone                   *string                                          `json:"phone"`
-	QualifiedInvoiceIssuer  *bool                                            `json:"qualified_invoice_issuer,omitempty"`
-	Shortcut1               *string                                          `json:"shortcut1"`
-	Shortcut2               *string                                          `json:"shortcut2"`
+	PayerWalletableId       *int64                                               `json:"payer_walletable_id"`
+	Phone                   *string                                              `json:"phone"`
+	QualifiedInvoiceIssuer  *bool                                                `json:"qualified_invoice_issuer,omitempty"`
+	Shortcut1               *string                                              `json:"shortcut1"`
+	Shortcut2               *string                                              `json:"shortcut2"`
 	TransferFeeHandlingSide *gen.PartnersResponsePartnersTransferFeeHandlingSide `json:"transfer_fee_handling_side,omitempty"`
-	UpdateDate              string                                           `json:"update_date"`
+	UpdateDate              string                                               `json:"update_date"`
 }
 
 func (s *PartnersService) ListIter(ctx context.Context, companyID int64, opts *ListPartnersOptions) Iterator[PartnerListItem] {

--- a/accounting/transfers_test.go
+++ b/accounting/transfers_test.go
@@ -143,12 +143,12 @@ func TestTransfersService_List(t *testing.T) {
 
 func TestTransfersService_Get(t *testing.T) {
 	tests := []struct {
-		name          string
-		companyID     int64
-		transferID    int64
-		mockStatus    int
-		mockBody      string
-		wantErr       bool
+		name           string
+		companyID      int64
+		transferID     int64
+		mockStatus     int
+		mockBody       string
+		wantErr        bool
 		wantTransferID int64
 	}{
 		{

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Test token validation
+// Test token validation.
 func TestIsTokenValid(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -280,7 +280,7 @@ func TestGetTokenInfo(t *testing.T) {
 	}
 }
 
-// Test CachedTokenSource
+// Test CachedTokenSource.
 func TestCachedTokenSource(t *testing.T) {
 	callCount := 0
 	validToken := &oauth2.Token{
@@ -443,7 +443,7 @@ func TestReuseTokenSourceWithCallback(t *testing.T) {
 	}
 }
 
-// Test error types
+// Test error types.
 func TestAuthError(t *testing.T) {
 	err := &AuthError{
 		Op:          "Exchange",
@@ -540,7 +540,7 @@ func TestIsInvalidGrantError(t *testing.T) {
 	}
 }
 
-// Mock token source for testing
+// Mock token source for testing.
 type mockTokenSource struct {
 	tokenFunc func() (*oauth2.Token, error)
 }
@@ -549,7 +549,7 @@ func (m *mockTokenSource) Token() (*oauth2.Token, error) {
 	return m.tokenFunc()
 }
 
-// Test full OAuth2 flow with mock server
+// Test full OAuth2 flow with mock server.
 func TestFullOAuth2Flow(t *testing.T) {
 	// Create a mock OAuth2 server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	// tokenFile is the path to the saved OAuth2 token
+	// tokenFile is the path to the saved OAuth2 token.
 	tokenFile = "../oauth/token.json"
 )
 

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -101,7 +101,7 @@ func main() {
 	fmt.Println("\n=== Example completed successfully ===")
 }
 
-// listRecentDeals demonstrates fetching recent deals with pagination
+// listRecentDeals demonstrates fetching recent deals with pagination.
 func listRecentDeals(ctx context.Context, client *accounting.Client, companyID int64) error {
 	// Set up options to fetch the first 5 deals
 	limit := int64(5)
@@ -143,7 +143,7 @@ func listRecentDeals(ctx context.Context, client *accounting.Client, companyID i
 	return nil
 }
 
-// listExpenseDeals demonstrates filtering deals by type
+// listExpenseDeals demonstrates filtering deals by type.
 func listExpenseDeals(ctx context.Context, client *accounting.Client, companyID int64) error {
 	// Set up options to filter expense deals
 	dealType := "expense"
@@ -183,7 +183,7 @@ func listExpenseDeals(ctx context.Context, client *accounting.Client, companyID 
 	return nil
 }
 
-// getSpecificDeal demonstrates fetching a single deal by ID
+// getSpecificDeal demonstrates fetching a single deal by ID.
 func getSpecificDeal(ctx context.Context, client *accounting.Client, companyID int64) error {
 	// First, get a deal ID from the list
 	limit := int64(1)

--- a/examples/oauth/main.go
+++ b/examples/oauth/main.go
@@ -38,11 +38,11 @@ import (
 )
 
 const (
-	// Port for the local callback server
+	// Port for the local callback server.
 	callbackPort = "8080"
-	// Callback path
+	// Callback path.
 	callbackPath = "/callback"
-	// Token file path
+	// Token file path.
 	tokenFile = "token.json"
 )
 
@@ -115,7 +115,7 @@ func main() {
 
 	// Start the callback server
 	server := &http.Server{
-		Addr: ":" + callbackPort,
+		Addr:    ":" + callbackPort,
 		Handler: callbackHandler(state, codeChan, errorChan),
 	}
 

--- a/tests/integration/deals_test.go
+++ b/tests/integration/deals_test.go
@@ -35,23 +35,23 @@ func TestDealsService_CRUD(t *testing.T) {
 			IssueDate: "2024-01-15",
 			Type:      gen.DealCreateParamsTypeExpense,
 			Details: []struct {
-				AccountItemCode *string `json:"account_item_code,omitempty"`
-				AccountItemId   *int64  `json:"account_item_id,omitempty"`
-				Amount          int64   `json:"amount"`
-				Description     *string `json:"description,omitempty"`
-				ItemCode        *string `json:"item_code,omitempty"`
-				ItemId          *int64  `json:"item_id,omitempty"`
-				SectionCode     *string `json:"section_code,omitempty"`
-				SectionId       *int64  `json:"section_id,omitempty"`
-				Segment1TagCode *string `json:"segment_1_tag_code,omitempty"`
-				Segment1TagId   *int64  `json:"segment_1_tag_id,omitempty"`
-				Segment2TagCode *string `json:"segment_2_tag_code,omitempty"`
-				Segment2TagId   *int64  `json:"segment_2_tag_id,omitempty"`
-				Segment3TagCode *string `json:"segment_3_tag_code,omitempty"`
-				Segment3TagId   *int64  `json:"segment_3_tag_id,omitempty"`
+				AccountItemCode *string  `json:"account_item_code,omitempty"`
+				AccountItemId   *int64   `json:"account_item_id,omitempty"`
+				Amount          int64    `json:"amount"`
+				Description     *string  `json:"description,omitempty"`
+				ItemCode        *string  `json:"item_code,omitempty"`
+				ItemId          *int64   `json:"item_id,omitempty"`
+				SectionCode     *string  `json:"section_code,omitempty"`
+				SectionId       *int64   `json:"section_id,omitempty"`
+				Segment1TagCode *string  `json:"segment_1_tag_code,omitempty"`
+				Segment1TagId   *int64   `json:"segment_1_tag_id,omitempty"`
+				Segment2TagCode *string  `json:"segment_2_tag_code,omitempty"`
+				Segment2TagId   *int64   `json:"segment_2_tag_id,omitempty"`
+				Segment3TagCode *string  `json:"segment_3_tag_code,omitempty"`
+				Segment3TagId   *int64   `json:"segment_3_tag_id,omitempty"`
 				TagIds          *[]int64 `json:"tag_ids,omitempty"`
-				TaxCode         int64   `json:"tax_code"`
-				Vat             *int64  `json:"vat,omitempty"`
+				TaxCode         int64    `json:"tax_code"`
+				Vat             *int64   `json:"vat,omitempty"`
 			}{
 				{
 					AccountItemId: &accountItemID,
@@ -193,18 +193,18 @@ func TestDealsService_CRUD(t *testing.T) {
 			IssueDate: "2024-01-25",
 			Type:      gen.DealUpdateParamsTypeExpense,
 			Details: []struct {
-				AccountItemId  int64   `json:"account_item_id"`
-				Amount         int64   `json:"amount"`
-				Description    *string `json:"description,omitempty"`
-				Id             *int64  `json:"id,omitempty"`
-				ItemId         *int64  `json:"item_id,omitempty"`
-				SectionId      *int64  `json:"section_id,omitempty"`
-				Segment1TagId  *int64  `json:"segment_1_tag_id,omitempty"`
-				Segment2TagId  *int64  `json:"segment_2_tag_id,omitempty"`
-				Segment3TagId  *int64  `json:"segment_3_tag_id,omitempty"`
-				TagIds         *[]int64 `json:"tag_ids,omitempty"`
-				TaxCode        int64   `json:"tax_code"`
-				Vat            *int64  `json:"vat,omitempty"`
+				AccountItemId int64    `json:"account_item_id"`
+				Amount        int64    `json:"amount"`
+				Description   *string  `json:"description,omitempty"`
+				Id            *int64   `json:"id,omitempty"`
+				ItemId        *int64   `json:"item_id,omitempty"`
+				SectionId     *int64   `json:"section_id,omitempty"`
+				Segment1TagId *int64   `json:"segment_1_tag_id,omitempty"`
+				Segment2TagId *int64   `json:"segment_2_tag_id,omitempty"`
+				Segment3TagId *int64   `json:"segment_3_tag_id,omitempty"`
+				TagIds        *[]int64 `json:"tag_ids,omitempty"`
+				TaxCode       int64    `json:"tax_code"`
+				Vat           *int64   `json:"vat,omitempty"`
 			}{
 				{
 					AccountItemId: accountItemID,

--- a/tests/integration/mockserver/server.go
+++ b/tests/integration/mockserver/server.go
@@ -102,21 +102,21 @@ type Request struct {
 
 // Deal represents a mock deal.
 type Deal struct {
-	ID         int64          `json:"id"`
-	CompanyID  int64          `json:"company_id"`
-	IssueDate  string         `json:"issue_date"`
-	DueDate    *string        `json:"due_date,omitempty"`
-	Amount     int64          `json:"amount"`
-	DueAmount  int64          `json:"due_amount"`
-	Type       string         `json:"type"`
-	PartnerID  *int64         `json:"partner_id,omitempty"`
-	RefNumber  *string        `json:"ref_number,omitempty"`
-	Status     string         `json:"status"`
-	Details    []DealDetail   `json:"details"`
-	Payments   []DealPayment  `json:"payments"`
-	Receipts   []DealReceipt  `json:"receipts"`
-	CreateTime string         `json:"created_at"`
-	UpdateTime string         `json:"updated_at"`
+	ID         int64         `json:"id"`
+	CompanyID  int64         `json:"company_id"`
+	IssueDate  string        `json:"issue_date"`
+	DueDate    *string       `json:"due_date,omitempty"`
+	Amount     int64         `json:"amount"`
+	DueAmount  int64         `json:"due_amount"`
+	Type       string        `json:"type"`
+	PartnerID  *int64        `json:"partner_id,omitempty"`
+	RefNumber  *string       `json:"ref_number,omitempty"`
+	Status     string        `json:"status"`
+	Details    []DealDetail  `json:"details"`
+	Payments   []DealPayment `json:"payments"`
+	Receipts   []DealReceipt `json:"receipts"`
+	CreateTime string        `json:"created_at"`
+	UpdateTime string        `json:"updated_at"`
 }
 
 // DealDetail represents a deal detail line.
@@ -132,11 +132,11 @@ type DealDetail struct {
 
 // DealPayment represents a deal payment.
 type DealPayment struct {
-	ID            int64  `json:"id"`
-	Date          string `json:"date"`
-	FromWalletID  int64  `json:"from_walletable_id"`
+	ID             int64  `json:"id"`
+	Date           string `json:"date"`
+	FromWalletID   int64  `json:"from_walletable_id"`
 	FromWalletType string `json:"from_walletable_type"`
-	Amount        int64  `json:"amount"`
+	Amount         int64  `json:"amount"`
 }
 
 // DealReceipt represents a deal receipt.
@@ -146,20 +146,20 @@ type DealReceipt struct {
 
 // Journal represents a mock journal entry.
 type Journal struct {
-	ID        int64  `json:"id"`
-	CompanyID int64  `json:"company_id"`
+	ID        int64 `json:"id"`
+	CompanyID int64 `json:"company_id"`
 }
 
 // WalletTxn represents a mock wallet transaction.
 type WalletTxn struct {
-	ID        int64  `json:"id"`
-	CompanyID int64  `json:"company_id"`
+	ID        int64 `json:"id"`
+	CompanyID int64 `json:"company_id"`
 }
 
 // Transfer represents a mock transfer.
 type Transfer struct {
-	ID        int64  `json:"id"`
-	CompanyID int64  `json:"company_id"`
+	ID        int64 `json:"id"`
+	CompanyID int64 `json:"company_id"`
 }
 
 // NewServer creates a new mock freee API server.

--- a/transport/logging_test.go
+++ b/transport/logging_test.go
@@ -123,7 +123,7 @@ func TestMaskSensitiveHeaders(t *testing.T) {
 	masked := maskSensitiveHeaders(headers)
 
 	tests := []struct {
-		header    string
+		header     string
 		shouldMask bool
 	}{
 		{"Content-Type", false},

--- a/transport/options.go
+++ b/transport/options.go
@@ -56,7 +56,7 @@ func WithUserAgent(userAgent string) Option {
 }
 
 // WithDefaultUserAgent sets the default User-Agent for the freee-api-go library.
-// The format is: "freee-api-go/VERSION (+github.com/u-masato/freee-api-go)"
+// The format is: "freee-api-go/VERSION (+github.com/u-masato/freee-api-go)".
 func WithDefaultUserAgent(version string) Option {
 	userAgent := "freee-api-go/" + version + " (+github.com/u-masato/freee-api-go)"
 	return WithUserAgent(userAgent)

--- a/transport/retry.go
+++ b/transport/retry.go
@@ -95,7 +95,7 @@ func (rt *RetryRoundTripper) SetBase(base http.RoundTripper) {
 }
 
 // calculateBackoff calculates the backoff delay for a given attempt.
-// Uses exponential backoff: initialDelay * 2^attempt
+// Uses exponential backoff: initialDelay * 2^attempt.
 func (rt *RetryRoundTripper) calculateBackoff(attempt int) time.Duration {
 	multiplier := math.Pow(2, float64(attempt))
 	delay := time.Duration(float64(rt.initialDelay) * multiplier)

--- a/transport/retry_test.go
+++ b/transport/retry_test.go
@@ -154,8 +154,8 @@ func TestRetryRoundTripperNonRetryableStatus(t *testing.T) {
 
 func TestIsRetryableStatusCode(t *testing.T) {
 	tests := []struct {
-		code       int
-		retryable  bool
+		code      int
+		retryable bool
 	}{
 		{http.StatusOK, false},
 		{http.StatusBadRequest, false},
@@ -215,7 +215,7 @@ func TestSetBaseRetry(t *testing.T) {
 	}
 }
 
-// mockRoundTripper is a test helper that returns errors
+// mockRoundTripper is a test helper that returns errors.
 type mockRoundTripper struct {
 	err error
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -54,9 +54,9 @@ func TestTransportWithOptions(t *testing.T) {
 
 func TestChainRoundTrippers(t *testing.T) {
 	tests := []struct {
-		name  string
-		rts   []http.RoundTripper
-		want  int // number of RoundTrippers
+		name string
+		rts  []http.RoundTripper
+		want int // number of RoundTrippers
 	}{
 		{
 			name: "empty",

--- a/transport/useragent.go
+++ b/transport/useragent.go
@@ -53,7 +53,7 @@ func (rt *UserAgentRoundTripper) SetBase(base http.RoundTripper) {
 }
 
 // DefaultUserAgent returns the default user agent string for this library.
-// Format: "freee-api-go/VERSION (+github.com/u-masato/freee-api-go)"
+// Format: "freee-api-go/VERSION (+github.com/u-masato/freee-api-go)".
 func DefaultUserAgent(version string) string {
 	if version == "" {
 		version = "dev"


### PR DESCRIPTION
## Summary
- Migrate golangci-lint configuration to v2 format
- Add `make fmt` target to Makefile
- Apply gofmt formatting to entire codebase

## Changes
- **`.golangci.yml`**: Update to v2 format
  - Add `version: "2"` (required for golangci-lint v2)
  - Move `gofmt`, `goimports` to `formatters` section
  - Remove `gosimple`, `stylecheck` (merged into `staticcheck` in v2)
  - Remove `exportloopref` (unnecessary in Go 1.22+)
  - Remove `output.format` (not supported in v2)

- **`Makefile`**: Add `make fmt` command

- **16 source files**: Apply consistent gofmt formatting

## Test plan
- [x] `golangci-lint run` executes successfully
- [x] `make fmt` works correctly
- [ ] `make test` passes