### PR TITLE
Add companies and walletables services

### DIFF
--- a/accounting/README.md
+++ b/accounting/README.md
@@ -8,6 +8,8 @@ freee 会計API用のFacadeパッケージ。
 - サービスごとのFacade提供
   - 取引（Deals）
   - 仕訳（Journals）
+  - 事業所（Companies）
+  - 口座（Walletables）
   - 取引先（Partners）
   - その他会計リソース
 - ページング処理の隠蔽
@@ -23,4 +25,10 @@ ac := accounting.NewClient(baseClient)
 deals, err := ac.Deals.List(ctx, &accounting.DealsListOptions{
     CompanyID: 123456,
 })
+
+// 事業所一覧取得
+companies, err := ac.Companies().List(ctx)
+
+// 口座一覧取得
+walletables, err := ac.Walletables().List(ctx, 123456, nil)
 ```

--- a/accounting/client.go
+++ b/accounting/client.go
@@ -43,9 +43,12 @@
 //
 //   - [DealsService]: 取引の管理 - 収入と支出
 //   - [JournalsService]: 仕訳の管理 - 会計エントリ
+//   - [CompaniesService]: 事業所の管理
 //   - [WalletTxnService]: 口座明細の管理
+//   - [WalletablesService]: 口座の管理
 //   - [TransfersService]: 振替の管理
 //   - [PartnersService]: 取引先の管理
+//   - [AccountItemsService]: 勘定科目の管理
 //
 // 使用例：
 //
@@ -159,7 +162,9 @@ type Client struct {
 	// Service clients (lazy initialization)
 	deals        *DealsService
 	journals     *JournalsService
+	companies    *CompaniesService
 	walletTxn    *WalletTxnService
+	walletables  *WalletablesService
 	transfers    *TransfersService
 	partners     *PartnersService
 	accountItems *AccountItemsService
@@ -231,6 +236,24 @@ func (c *Client) Journals() *JournalsService {
 	return c.journals
 }
 
+// Companies returns the CompaniesService for managing companies (事業所).
+//
+// The service is lazily initialized on first access.
+//
+// Example:
+//
+//	companies := accountingClient.Companies()
+//	list, err := companies.List(ctx)
+func (c *Client) Companies() *CompaniesService {
+	if c.companies == nil {
+		c.companies = &CompaniesService{
+			client:    c.client,
+			genClient: c.genClient,
+		}
+	}
+	return c.companies
+}
+
 // WalletTxns returns the WalletTxnService for managing wallet transactions (口座明細).
 //
 // The service is lazily initialized on first access.
@@ -247,6 +270,24 @@ func (c *Client) WalletTxns() *WalletTxnService {
 		}
 	}
 	return c.walletTxn
+}
+
+// Walletables returns the WalletablesService for managing walletables (口座).
+//
+// The service is lazily initialized on first access.
+//
+// Example:
+//
+//	walletables := accountingClient.Walletables()
+//	list, err := walletables.List(ctx, companyID, nil)
+func (c *Client) Walletables() *WalletablesService {
+	if c.walletables == nil {
+		c.walletables = &WalletablesService{
+			client:    c.client,
+			genClient: c.genClient,
+		}
+	}
+	return c.walletables
 }
 
 // Transfers returns the TransfersService for managing transfers (取引（振替）).

--- a/accounting/client_test.go
+++ b/accounting/client_test.go
@@ -129,6 +129,32 @@ func TestClient_Journals(t *testing.T) {
 	}
 }
 
+func TestClient_Companies(t *testing.T) {
+	baseClient := client.NewClient()
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	companies1 := accountingClient.Companies()
+	if companies1 == nil {
+		t.Error("Companies() returned nil")
+		return
+	}
+
+	companies2 := accountingClient.Companies()
+	if companies1 != companies2 {
+		t.Error("Companies() returned different instances, expected same instance")
+	}
+
+	if companies1.client == nil {
+		t.Error("CompaniesService.client is nil")
+	}
+	if companies1.genClient == nil {
+		t.Error("CompaniesService.genClient is nil")
+	}
+}
+
 func TestClient_WalletTxns(t *testing.T) {
 	baseClient := client.NewClient()
 	accountingClient, err := NewClient(baseClient)
@@ -155,6 +181,32 @@ func TestClient_WalletTxns(t *testing.T) {
 	}
 	if walletTxns1.genClient == nil {
 		t.Error("WalletTxnService.genClient is nil")
+	}
+}
+
+func TestClient_Walletables(t *testing.T) {
+	baseClient := client.NewClient()
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	walletables1 := accountingClient.Walletables()
+	if walletables1 == nil {
+		t.Error("Walletables() returned nil")
+		return
+	}
+
+	walletables2 := accountingClient.Walletables()
+	if walletables1 != walletables2 {
+		t.Error("Walletables() returned different instances, expected same instance")
+	}
+
+	if walletables1.client == nil {
+		t.Error("WalletablesService.client is nil")
+	}
+	if walletables1.genClient == nil {
+		t.Error("WalletablesService.genClient is nil")
 	}
 }
 
@@ -231,7 +283,9 @@ func TestClient_AllServices(t *testing.T) {
 
 	deals := accountingClient.Deals()
 	journals := accountingClient.Journals()
+	companies := accountingClient.Companies()
 	walletTxns := accountingClient.WalletTxns()
+	walletables := accountingClient.Walletables()
 	transfers := accountingClient.Transfers()
 
 	if deals == nil {
@@ -240,8 +294,14 @@ func TestClient_AllServices(t *testing.T) {
 	if journals == nil {
 		t.Error("Journals service is nil")
 	}
+	if companies == nil {
+		t.Error("Companies service is nil")
+	}
 	if walletTxns == nil {
 		t.Error("WalletTxns service is nil")
+	}
+	if walletables == nil {
+		t.Error("Walletables service is nil")
 	}
 	if transfers == nil {
 		t.Error("Transfers service is nil")

--- a/accounting/companies.go
+++ b/accounting/companies.go
@@ -1,0 +1,144 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/u-masato/freee-api-go/internal/gen"
+)
+
+// ListCompaniesResult contains the result of listing companies.
+type ListCompaniesResult struct {
+	// Companies is the response containing companies
+	Companies *gen.CompanyIndexResponse
+
+	// Count is the number of companies returned in this response
+	Count int
+}
+
+// GetCompanyOptions contains optional parameters for retrieving a company.
+//
+// Note: These flags are include-only parameters. Set to true to include
+// the corresponding data in the response.
+type GetCompanyOptions struct {
+	// Details includes account items, taxes, items, partners, sections, tags, and walletables
+	Details *bool
+
+	// AccountItems includes account items in the response
+	AccountItems *bool
+
+	// Taxes includes tax codes in the response
+	Taxes *bool
+
+	// Items includes items in the response
+	Items *bool
+
+	// Partners includes partners in the response
+	Partners *bool
+
+	// Sections includes sections in the response
+	Sections *bool
+
+	// Tags includes tags in the response
+	Tags *bool
+
+	// Walletables includes walletables in the response
+	Walletables *bool
+}
+
+// List retrieves a list of companies the user belongs to.
+//
+// Example:
+//
+//	result, err := companiesService.List(ctx)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, company := range result.Companies.Companies {
+//	    fmt.Printf("Company ID: %d, Name: %s\n", company.Id, *company.Name)
+//	}
+func (s *CompaniesService) List(ctx context.Context) (*ListCompaniesResult, error) {
+	resp, err := s.genClient.GetCompaniesWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list companies: %w", err)
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return &ListCompaniesResult{
+		Companies: resp.JSON200,
+		Count:     len(resp.JSON200.Companies),
+	}, nil
+}
+
+// Get retrieves a single company by ID.
+//
+// Example:
+//
+//	opts := &accounting.GetCompanyOptions{
+//	    Details: boolPtr(true),
+//	}
+//	company, err := companiesService.Get(ctx, companyID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Company ID: %d, Name: %s\n", company.Company.Id, company.Company.DisplayName)
+func (s *CompaniesService) Get(ctx context.Context, companyID int64, opts *GetCompanyOptions) (*gen.CompanyResponse, error) {
+	params := buildGetCompanyParams(opts)
+
+	resp, err := s.genClient.GetCompanyWithResponse(ctx, companyID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get company: %w", err)
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON200, nil
+}
+
+func buildGetCompanyParams(opts *GetCompanyOptions) *gen.GetCompanyParams {
+	if opts == nil {
+		return nil
+	}
+
+	params := &gen.GetCompanyParams{}
+
+	if opts.Details != nil && *opts.Details {
+		details := gen.GetCompanyParamsDetailsTrue
+		params.Details = &details
+	}
+	if opts.AccountItems != nil && *opts.AccountItems {
+		accountItems := gen.GetCompanyParamsAccountItemsTrue
+		params.AccountItems = &accountItems
+	}
+	if opts.Taxes != nil && *opts.Taxes {
+		taxes := gen.GetCompanyParamsTaxesTrue
+		params.Taxes = &taxes
+	}
+	if opts.Items != nil && *opts.Items {
+		items := gen.GetCompanyParamsItemsTrue
+		params.Items = &items
+	}
+	if opts.Partners != nil && *opts.Partners {
+		partners := gen.GetCompanyParamsPartnersTrue
+		params.Partners = &partners
+	}
+	if opts.Sections != nil && *opts.Sections {
+		sections := gen.GetCompanyParamsSectionsTrue
+		params.Sections = &sections
+	}
+	if opts.Tags != nil && *opts.Tags {
+		tags := gen.GetCompanyParamsTagsTrue
+		params.Tags = &tags
+	}
+	if opts.Walletables != nil && *opts.Walletables {
+		walletables := gen.GetCompanyParamsWalletablesTrue
+		params.Walletables = &walletables
+	}
+
+	return params
+}

--- a/accounting/companies_test.go
+++ b/accounting/companies_test.go
@@ -1,0 +1,131 @@
+package accounting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/u-masato/freee-api-go/client"
+)
+
+func TestCompaniesService_List(t *testing.T) {
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"companies": [
+			{
+				"id": 1,
+				"company_number": "1234567890",
+				"display_name": "Company A",
+				"name": "Company A",
+				"role": "admin"
+			},
+			{
+				"id": 2,
+				"company_number": "0987654321",
+				"display_name": "Company B",
+				"name": "Company B",
+				"role": "read_only"
+			}
+		]
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/1/companies" {
+			t.Errorf("expected path /api/1/companies, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	companiesService := accountingClient.Companies()
+	result, err := companiesService.List(context.Background())
+
+	if err != nil {
+		t.Errorf("List() unexpected error = %v", err)
+		return
+	}
+	if result == nil {
+		t.Error("List() returned nil result")
+		return
+	}
+	if result.Count != 2 {
+		t.Errorf("List() got count %d, want %d", result.Count, 2)
+	}
+}
+
+func TestCompaniesService_Get(t *testing.T) {
+	companyID := int64(123)
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"company": {
+			"id": 123,
+			"company_number": "1234567890",
+			"display_name": "Test Company",
+			"corporate_number": "1234567890123",
+			"amount_fraction": 0,
+			"fiscal_years": []
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/1/companies/123"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		if query.Get("details") != "true" {
+			t.Errorf("expected details=true, got %s", query.Get("details"))
+		}
+		if query.Get("walletables") != "true" {
+			t.Errorf("expected walletables=true, got %s", query.Get("walletables"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	opts := &GetCompanyOptions{
+		Details:     boolPtr(true),
+		Walletables: boolPtr(true),
+	}
+
+	companiesService := accountingClient.Companies()
+	company, err := companiesService.Get(context.Background(), companyID, opts)
+
+	if err != nil {
+		t.Errorf("Get() unexpected error = %v", err)
+		return
+	}
+	if company == nil {
+		t.Error("Get() returned nil company")
+		return
+	}
+	if company.Company.Id != companyID {
+		t.Errorf("Get() got company ID %d, want %d", company.Company.Id, companyID)
+	}
+}

--- a/accounting/services.go
+++ b/accounting/services.go
@@ -40,6 +40,22 @@ type JournalsService struct {
 	genClient *gen.ClientWithResponses
 }
 
+// CompaniesService provides operations for managing companies (事業所).
+//
+// Companies represent organizations the authenticated user belongs to.
+//
+// All methods require a context.Context for cancellation and timeouts.
+//
+// Example:
+//
+//	companies := accountingClient.Companies()
+//	list, err := companies.List(ctx)
+//	company, err := companies.Get(ctx, companyID, nil)
+type CompaniesService struct {
+	client    *client.Client
+	genClient *gen.ClientWithResponses
+}
+
 // WalletTxnService provides operations for managing wallet transactions (口座明細).
 //
 // Wallet transactions represent entries in bank accounts, credit cards, and other
@@ -54,6 +70,23 @@ type JournalsService struct {
 //	// Future: list, err := walletTxns.List(ctx, companyID, walletableID, nil)
 //	// Future: txn, err := walletTxns.Get(ctx, companyID, txnID)
 type WalletTxnService struct {
+	client    *client.Client
+	genClient *gen.ClientWithResponses
+}
+
+// WalletablesService provides operations for managing walletables (口座).
+//
+// Walletables represent bank accounts, credit cards, and other payment accounts
+// registered in freee. These can be used for transactions and reconciliations.
+//
+// All methods require a context.Context for cancellation and timeouts.
+//
+// Example:
+//
+//	walletables := accountingClient.Walletables()
+//	list, err := walletables.List(ctx, companyID, nil)
+//	walletable, err := walletables.Get(ctx, companyID, "bank_account", walletableID, nil)
+type WalletablesService struct {
 	client    *client.Client
 	genClient *gen.ClientWithResponses
 }

--- a/accounting/walletables.go
+++ b/accounting/walletables.go
@@ -1,0 +1,239 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/u-masato/freee-api-go/internal/gen"
+)
+
+// ListWalletablesOptions contains optional parameters for listing walletables.
+type ListWalletablesOptions struct {
+	// Type filters by account type (口座種別)
+	// Values: "bank_account" (銀行口座), "credit_card" (クレジットカード), "wallet" (その他の決済口座)
+	Type *string
+
+	// WithBalance includes walletable balance information
+	WithBalance *bool
+
+	// WithLastSyncedAt includes last synced timestamp
+	WithLastSyncedAt *bool
+
+	// WithSyncStatus includes sync status
+	WithSyncStatus *bool
+
+	// StartUpdateDate filters by update date start (yyyy-mm-dd)
+	StartUpdateDate *string
+
+	// EndUpdateDate filters by update date end (yyyy-mm-dd)
+	EndUpdateDate *string
+}
+
+// ListWalletablesResult contains the result of listing walletables.
+type ListWalletablesResult struct {
+	// Walletables is the list of walletables
+	Walletables []gen.Walletable
+
+	// Count is the number of walletables returned in this response
+	Count int
+
+	// UpToDate indicates whether the aggregation is up to date
+	UpToDate *bool
+}
+
+// GetWalletableOptions contains optional parameters for retrieving a walletable.
+type GetWalletableOptions struct {
+	// WithLastSyncedAt includes last synced timestamp
+	WithLastSyncedAt *bool
+
+	// WithSyncStatus includes sync status
+	WithSyncStatus *bool
+}
+
+// GetWalletableResult contains the result of retrieving a walletable.
+type GetWalletableResult struct {
+	// Walletable is the walletable details
+	Walletable gen.Walletable
+
+	// UpToDate indicates whether the aggregation is up to date
+	UpToDate *bool
+}
+
+// List retrieves a list of walletables for the specified company.
+//
+// Example:
+//
+//	opts := &accounting.ListWalletablesOptions{
+//	    Type:        stringPtr("bank_account"),
+//	    WithBalance: boolPtr(true),
+//	}
+//	result, err := walletablesService.List(ctx, companyID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	for _, walletable := range result.Walletables {
+//	    fmt.Printf("Walletable ID: %d, Name: %s\n", walletable.Id, walletable.Name)
+//	}
+func (s *WalletablesService) List(ctx context.Context, companyID int64, opts *ListWalletablesOptions) (*ListWalletablesResult, error) {
+	params := &gen.GetWalletablesParams{
+		CompanyId: companyID,
+	}
+
+	if opts != nil {
+		params.WithBalance = opts.WithBalance
+		params.WithLastSyncedAt = opts.WithLastSyncedAt
+		params.WithSyncStatus = opts.WithSyncStatus
+		params.StartUpdateDate = opts.StartUpdateDate
+		params.EndUpdateDate = opts.EndUpdateDate
+
+		if opts.Type != nil {
+			walletableType := gen.GetWalletablesParamsType(*opts.Type)
+			params.Type = &walletableType
+		}
+	}
+
+	resp, err := s.genClient.GetWalletablesWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list walletables: %w", err)
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	var upToDate *bool
+	if resp.JSON200.Meta != nil {
+		upToDate = resp.JSON200.Meta.UpToDate
+	}
+
+	return &ListWalletablesResult{
+		Walletables: resp.JSON200.Walletables,
+		Count:       len(resp.JSON200.Walletables),
+		UpToDate:    upToDate,
+	}, nil
+}
+
+// Get retrieves a single walletable by type and ID.
+//
+// Example:
+//
+//	opts := &accounting.GetWalletableOptions{
+//	    WithSyncStatus: boolPtr(true),
+//	}
+//	result, err := walletablesService.Get(ctx, companyID, "bank_account", walletableID, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Walletable ID: %d, Name: %s\n", result.Walletable.Id, result.Walletable.Name)
+func (s *WalletablesService) Get(ctx context.Context, companyID int64, walletableType string, walletableID int64, opts *GetWalletableOptions) (*GetWalletableResult, error) {
+	params := &gen.GetWalletableParams{
+		CompanyId: companyID,
+	}
+
+	if opts != nil {
+		params.WithLastSyncedAt = opts.WithLastSyncedAt
+		params.WithSyncStatus = opts.WithSyncStatus
+	}
+
+	pType := gen.GetWalletableParamsType(walletableType)
+	resp, err := s.genClient.GetWalletableWithResponse(ctx, pType, walletableID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get walletable: %w", err)
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	var upToDate *bool
+	if resp.JSON200.Meta != nil {
+		upToDate = resp.JSON200.Meta.UpToDate
+	}
+
+	return &GetWalletableResult{
+		Walletable: resp.JSON200.Walletable,
+		UpToDate:   upToDate,
+	}, nil
+}
+
+// Create creates a new walletable.
+//
+// Example:
+//
+//	params := gen.WalletableCreateParams{
+//	    CompanyId: companyID,
+//	    Name:      "Main Wallet",
+//	    Type:      "wallet",
+//	}
+//	walletable, err := walletablesService.Create(ctx, params)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Created walletable ID: %d\n", walletable.Walletable.Id)
+func (s *WalletablesService) Create(ctx context.Context, params gen.WalletableCreateParams) (*gen.WalletableCreateResponse, error) {
+	resp, err := s.genClient.CreateWalletableWithResponse(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create walletable: %w", err)
+	}
+
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	return resp.JSON201, nil
+}
+
+// Update updates an existing walletable.
+//
+// Example:
+//
+//	params := gen.WalletableUpdateParams{
+//	    CompanyId: companyID,
+//	    Name:      "Updated Wallet",
+//	}
+//	walletable, err := walletablesService.Update(ctx, "wallet", walletableID, params)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Updated walletable ID: %d\n", walletable.Id)
+func (s *WalletablesService) Update(ctx context.Context, walletableType string, walletableID int64, params gen.WalletableUpdateParams) (*gen.WalletableUpdateResponse, error) {
+	pType := gen.UpdateWalletableParamsType(walletableType)
+	resp, err := s.genClient.UpdateWalletableWithResponse(ctx, pType, walletableID, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update walletable: %w", err)
+	}
+
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status())
+	}
+
+	walletable := resp.JSON200.Walletable
+	return &walletable, nil
+}
+
+// Delete deletes a walletable by type and ID.
+//
+// Example:
+//
+//	err := walletablesService.Delete(ctx, companyID, "wallet", walletableID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println("Walletable deleted successfully")
+func (s *WalletablesService) Delete(ctx context.Context, companyID int64, walletableType string, walletableID int64) error {
+	params := &gen.DestroyWalletableParams{
+		CompanyId: companyID,
+	}
+
+	pType := gen.DestroyWalletableParamsType(walletableType)
+	resp, err := s.genClient.DestroyWalletableWithResponse(ctx, pType, walletableID, params)
+	if err != nil {
+		return fmt.Errorf("failed to delete walletable: %w", err)
+	}
+
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("failed to delete walletable: %s", resp.Status())
+	}
+
+	return nil
+}

--- a/accounting/walletables_test.go
+++ b/accounting/walletables_test.go
@@ -1,0 +1,329 @@
+package accounting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/u-masato/freee-api-go/client"
+	"github.com/u-masato/freee-api-go/internal/gen"
+)
+
+func TestWalletablesService_List(t *testing.T) {
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"walletables": [
+			{"id": 1, "name": "Main Wallet", "type": "wallet"},
+			{"id": 2, "name": "Bank Account", "type": "bank_account"}
+		],
+		"meta": {
+			"up_to_date": true
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/1/walletables" {
+			t.Errorf("expected path /api/1/walletables, got %s", r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		if query.Get("company_id") != "1" {
+			t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+		}
+		if query.Get("type") != "wallet" {
+			t.Errorf("expected type=wallet, got %s", query.Get("type"))
+		}
+		if query.Get("with_balance") != "true" {
+			t.Errorf("expected with_balance=true, got %s", query.Get("with_balance"))
+		}
+		if query.Get("with_sync_status") != "true" {
+			t.Errorf("expected with_sync_status=true, got %s", query.Get("with_sync_status"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	opts := &ListWalletablesOptions{
+		Type:           stringPtr("wallet"),
+		WithBalance:    boolPtr(true),
+		WithSyncStatus: boolPtr(true),
+	}
+
+	walletablesService := accountingClient.Walletables()
+	result, err := walletablesService.List(context.Background(), 1, opts)
+
+	if err != nil {
+		t.Errorf("List() unexpected error = %v", err)
+		return
+	}
+	if result == nil {
+		t.Error("List() returned nil result")
+		return
+	}
+	if result.Count != 2 {
+		t.Errorf("List() got count %d, want %d", result.Count, 2)
+	}
+	if result.UpToDate == nil || !*result.UpToDate {
+		t.Error("List() expected up_to_date=true")
+	}
+}
+
+func TestWalletablesService_Get(t *testing.T) {
+	companyID := int64(1)
+	walletableID := int64(123)
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"walletable": {
+			"id": 123,
+			"name": "Main Wallet",
+			"type": "wallet"
+		},
+		"meta": {
+			"up_to_date": true
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		expectedPath := "/api/1/walletables/wallet/123"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		if query.Get("company_id") != "1" {
+			t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+		}
+		if query.Get("with_last_synced_at") != "true" {
+			t.Errorf("expected with_last_synced_at=true, got %s", query.Get("with_last_synced_at"))
+		}
+		if query.Get("with_sync_status") != "true" {
+			t.Errorf("expected with_sync_status=true, got %s", query.Get("with_sync_status"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	opts := &GetWalletableOptions{
+		WithLastSyncedAt: boolPtr(true),
+		WithSyncStatus:   boolPtr(true),
+	}
+
+	walletablesService := accountingClient.Walletables()
+	result, err := walletablesService.Get(context.Background(), companyID, "wallet", walletableID, opts)
+
+	if err != nil {
+		t.Errorf("Get() unexpected error = %v", err)
+		return
+	}
+	if result == nil {
+		t.Error("Get() returned nil result")
+		return
+	}
+	if result.Walletable.Id != walletableID {
+		t.Errorf("Get() got walletable ID %d, want %d", result.Walletable.Id, walletableID)
+	}
+	if result.UpToDate == nil || !*result.UpToDate {
+		t.Error("Get() expected up_to_date=true")
+	}
+}
+
+func TestWalletablesService_Create(t *testing.T) {
+	mockStatus := http.StatusCreated
+	mockBody := `{
+		"walletable": {
+			"id": 999,
+			"bank_id": 1,
+			"name": "New Wallet",
+			"type": "wallet"
+		}
+	}`
+	wantID := int64(999)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/1/walletables" {
+			t.Errorf("expected path /api/1/walletables, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	params := gen.WalletableCreateParams{
+		CompanyId: 1,
+		Name:      "New Wallet",
+		Type:      "wallet",
+	}
+
+	walletablesService := accountingClient.Walletables()
+	walletable, err := walletablesService.Create(context.Background(), params)
+
+	if err != nil {
+		t.Errorf("Create() unexpected error = %v", err)
+		return
+	}
+	if walletable == nil {
+		t.Error("Create() returned nil walletable")
+		return
+	}
+	if walletable.Walletable.Id != wantID {
+		t.Errorf("Create() got walletable ID %d, want %d", walletable.Walletable.Id, wantID)
+	}
+}
+
+func TestWalletablesService_Update(t *testing.T) {
+	walletableID := int64(123)
+	mockStatus := http.StatusOK
+	mockBody := `{
+		"walletable": {
+			"id": 123,
+			"name": "Updated Wallet",
+			"type": "wallet"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT request, got %s", r.Method)
+		}
+		expectedPath := "/api/1/walletables/wallet/123"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(mockStatus)
+		w.Write([]byte(mockBody))
+	}))
+	defer server.Close()
+
+	baseClient := client.NewClient(client.WithBaseURL(server.URL))
+	accountingClient, err := NewClient(baseClient)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	params := gen.WalletableUpdateParams{
+		CompanyId: 1,
+		Name:      "Updated Wallet",
+	}
+
+	walletablesService := accountingClient.Walletables()
+	walletable, err := walletablesService.Update(context.Background(), "wallet", walletableID, params)
+
+	if err != nil {
+		t.Errorf("Update() unexpected error = %v", err)
+		return
+	}
+	if walletable == nil {
+		t.Error("Update() returned nil walletable")
+		return
+	}
+	if walletable.Id != walletableID {
+		t.Errorf("Update() got walletable ID %d, want %d", walletable.Id, walletableID)
+	}
+}
+
+func TestWalletablesService_Delete(t *testing.T) {
+	tests := []struct {
+		name         string
+		companyID    int64
+		walletableID int64
+		mockStatus   int
+		wantErr      bool
+	}{
+		{
+			name:         "successful delete",
+			companyID:    1,
+			walletableID: 123,
+			mockStatus:   http.StatusNoContent,
+			wantErr:      false,
+		},
+		{
+			name:         "delete with 200 OK",
+			companyID:    1,
+			walletableID: 456,
+			mockStatus:   http.StatusOK,
+			wantErr:      false,
+		},
+		{
+			name:         "delete not found",
+			companyID:    1,
+			walletableID: 999,
+			mockStatus:   http.StatusNotFound,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE request, got %s", r.Method)
+				}
+				expectedPath := "/api/1/walletables/wallet/" + strconv.FormatInt(tt.walletableID, 10)
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected path /api/1/walletables/wallet/%d, got %s", tt.walletableID, r.URL.Path)
+				}
+
+				query := r.URL.Query()
+				if query.Get("company_id") != "1" {
+					t.Errorf("expected company_id=1, got %s", query.Get("company_id"))
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.mockStatus)
+			}))
+			defer server.Close()
+
+			baseClient := client.NewClient(client.WithBaseURL(server.URL))
+			accountingClient, err := NewClient(baseClient)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			walletablesService := accountingClient.Walletables()
+			err = walletablesService.Delete(context.Background(), tt.companyID, "wallet", tt.walletableID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add Companies service wrappers for /api/1/companies and /api/1/companies/{id}
- add Walletables service wrappers for list/get/create/update/delete
- wire new services into the accounting client and update docs/tests

## Testing
- go test ./...